### PR TITLE
Improve perf with benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,34 +27,25 @@ $ npm install media-typer
 
 ## API
 
-<!-- eslint-disable no-unused-vars -->
-
 ```js
 var typer = require("media-typer");
 ```
 
 ### typer.parse(string)
 
-<!-- eslint-disable no-undef, no-unused-vars -->
-
 ```js
 var obj = typer.parse("image/svg+xml");
 ```
 
-Parse a media type string. This will return an object with the following
-properties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):
+Parse a media type string. This will return an object with the following properties:
 
 - `type`: The type of the media type (always lower case). Example: `'image'`
-
 - `subtype`: The subtype of the media type (always lower case). Example: `'svg'`
-
-- `suffix`: The suffix of the media type (always lower case). Example: `'xml'`
+- `suffix`: Optional suffix of the media type (always lower case). Example: `'xml'`
 
 If the given type string is invalid, then a `TypeError` is thrown.
 
 ### typer.format(obj)
-
-<!-- eslint-disable no-undef, no-unused-vars -->
 
 ```js
 var obj = typer.format({ type: "image", subtype: "svg", suffix: "xml" });
@@ -67,8 +58,6 @@ documentation for `typer.parse(string)`.
 If any of the given object values are invalid, then a `TypeError` is thrown.
 
 ### typer.test(string)
-
-<!-- eslint-disable no-undef, no-unused-vars -->
 
 ```js
 var valid = typer.test("image/svg+xml");

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dist/"
   ],
   "scripts": {
+    "bench": "vitest bench",
     "build": "ts-scripts build",
     "format": "ts-scripts format",
     "prepare": "ts-scripts install",

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,0 +1,40 @@
+import { bench, describe } from "vitest";
+import * as typer from "./index.js";
+
+describe("typer.format", () => {
+  bench("basic type", () => {
+    typer.format({ type: "text", subtype: "html" });
+  });
+
+  bench("type with suffix", () => {
+    typer.format({ type: "image", subtype: "svg", suffix: "xml" });
+  });
+});
+
+describe("typer.parse", () => {
+  bench("basic type", () => {
+    typer.parse("text/html");
+  });
+
+  bench("type with suffix", () => {
+    typer.parse("image/svg+xml");
+  });
+
+  bench("upper-case type with suffix", () => {
+    typer.parse("IMAGE/SVG+XML");
+  });
+});
+
+describe("typer.test", () => {
+  bench("basic type", () => {
+    typer.test("text/html");
+  });
+
+  bench("type with suffix", () => {
+    typer.test("image/svg+xml");
+  });
+
+  bench("invalid type", () => {
+    typer.test("text/plain,wrong");
+  });
+});

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -25,38 +25,45 @@ describe("typer.format", () => {
     expect(str).toBe("image/svg+xml");
   });
 
-  it("should require argument", () => {
-    expect(() => typer.format(undefined as never)).toThrow(/obj.*required/);
+  it("should maintain case", () => {
+    const str = typer.format({ type: "Text", subtype: "Html" });
+    expect(str).toBe("Text/Html");
   });
 
-  it("should reject non-objects", () => {
-    expect(() => typer.format(7 as never)).toThrow(/obj.*required/);
+  it("should allow + in subtype", () => {
+    const str = typer.format({ type: "application", subtype: "vnd.api+json" });
+    expect(str).toBe("application/vnd.api+json");
   });
 
   it("should require type", () => {
-    expect(() => typer.format({} as never)).toThrow(/invalid type/);
+    expect(() => typer.format({} as never)).toThrow(/Invalid type/);
   });
 
   it("should reject invalid type", () => {
     expect(() => typer.format({ type: "text/", subtype: "html" })).toThrow(
-      /invalid type/,
+      /Invalid type/,
     );
   });
 
   it("should require subtype", () => {
     expect(() => typer.format({ type: "text" } as never)).toThrow(
-      /invalid subtype/,
+      /Invalid subtype/,
     );
   });
 
   it("should reject invalid subtype", () => {
     const obj = { type: "text", subtype: "html/" };
-    expect(() => typer.format(obj)).toThrow(/invalid subtype/);
+    expect(() => typer.format(obj)).toThrow(/Invalid subtype/);
+  });
+
+  it("should reject empty suffix", () => {
+    const obj = { type: "text", subtype: "html", suffix: "" };
+    expect(() => typer.format(obj)).toThrow(/Invalid suffix/);
   });
 
   it("should reject invalid suffix", () => {
     const obj = { type: "image", subtype: "svg", suffix: "xml\\" };
-    expect(() => typer.format(obj)).toThrow(/invalid suffix/);
+    expect(() => typer.format(obj)).toThrow(/Invalid suffix/);
   });
 });
 
@@ -83,16 +90,8 @@ describe("typer.parse", () => {
 
   invalidTypes.forEach((type) => {
     it(`should throw on invalid media type ${JSON.stringify(type)}`, () => {
-      expect(() => typer.parse(type)).toThrow(/invalid media type/);
+      expect(() => typer.parse(type)).toThrow(/Invalid media type/);
     });
-  });
-
-  it("should require argument", () => {
-    expect(() => typer.parse(undefined as never)).toThrow(/string.*required/);
-  });
-
-  it("should reject non-strings", () => {
-    expect(() => typer.parse(7 as never)).toThrow(/string.*required/);
   });
 });
 
@@ -113,13 +112,5 @@ describe("typer.test", () => {
     it(`should fail invalid media type ${JSON.stringify(type)}`, () => {
       expect(typer.test(type)).toBe(false);
     });
-  });
-
-  it("should require argument", () => {
-    expect(() => typer.test(undefined as never)).toThrow(/string.*required/);
-  });
-
-  it("should reject non-strings", () => {
-    expect(() => typer.test(7 as never)).toThrow(/string.*required/);
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -88,6 +88,13 @@ describe("typer.parse", () => {
     expect(type.suffix).toBe("xml");
   });
 
+  it("should parse with multiple + in subtype", () => {
+    const type = typer.parse("application/vnd.api+json+gzip");
+    expect(type.type).toBe("application");
+    expect(type.subtype).toBe("vnd.api+json");
+    expect(type.suffix).toBe("gzip");
+  });
+
   invalidTypes.forEach((type) => {
     it(`should throw on invalid media type ${JSON.stringify(type)}`, () => {
       expect(() => typer.parse(type)).toThrow(/Invalid media type/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,10 @@
  * ALPHA =  %x41-5A / %x61-7A   ; A-Z / a-z
  * DIGIT =  %x30-39             ; 0-9
  */
-const subtypeNameRegExp = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.-]{0,126}$/;
+const subtypeNameRegExp = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}$/;
 const typeNameRegExp = /^[A-Za-z0-9][A-Za-z0-9!#$&^_-]{0,126}$/;
 const typeRegExp =
-  /^ *([A-Za-z0-9][A-Za-z0-9!#$&^_-]{0,126})\/([A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}) *$/;
+  /^[A-Za-z0-9][A-Za-z0-9!#$&^_-]{0,126}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}$/;
 
 /**
  * Media type object.
@@ -41,27 +41,21 @@ export interface MediaType {
  * Format object to media type.
  */
 export function format(obj: MediaType): string {
-  if (!obj || typeof obj !== "object") {
-    throw new TypeError("argument obj is required");
-  }
-
-  const subtype = obj.subtype;
-  const suffix = obj.suffix;
-  const type = obj.type;
+  const { type, subtype, suffix } = obj;
 
   if (!type || !typeNameRegExp.test(type)) {
-    throw new TypeError("invalid type");
+    throw new TypeError(`Invalid type: ${type}`);
   }
 
   if (!subtype || !subtypeNameRegExp.test(subtype)) {
-    throw new TypeError("invalid subtype");
+    throw new TypeError(`Invalid subtype: ${subtype}`);
   }
 
   let str = type + "/" + subtype;
 
-  if (suffix) {
+  if (suffix !== undefined) {
     if (!typeNameRegExp.test(suffix)) {
-      throw new TypeError("invalid suffix");
+      throw new TypeError(`Invalid suffix: ${suffix}`);
     }
 
     str += "+" + suffix;
@@ -74,22 +68,13 @@ export function format(obj: MediaType): string {
  * Parse media type to object.
  */
 export function parse(str: string): MediaType {
-  if (!str) {
-    throw new TypeError("argument string is required");
+  if (!typeRegExp.test(str)) {
+    throw new TypeError(`Invalid media type: ${str}`);
   }
 
-  if (typeof str !== "string") {
-    throw new TypeError("argument string is required to be a string");
-  }
-
-  const match = typeRegExp.exec(str.toLowerCase());
-
-  if (!match) {
-    throw new TypeError("invalid media type");
-  }
-
-  const type = match[1];
-  let subtype = match[2];
+  const slashIndex = str.indexOf("/");
+  const type = str.slice(0, slashIndex).toLowerCase();
+  let subtype = str.slice(slashIndex + 1).toLowerCase();
   let suffix: string | undefined;
 
   const index = subtype.lastIndexOf("+");
@@ -105,13 +90,5 @@ export function parse(str: string): MediaType {
  * Test media type.
  */
 export function test(str: string): boolean {
-  if (!str) {
-    throw new TypeError("argument string is required");
-  }
-
-  if (typeof str !== "string") {
-    throw new TypeError("argument string is required to be a string");
-  }
-
-  return typeRegExp.test(str.toLowerCase());
+  return typeRegExp.test(str);
 }


### PR DESCRIPTION
Not a huge difference but I _think_ there's minor improvements from switching to `.test` without any capturing groups and doing an `indexOf`. Doing an `indexOf` first, splitting, and doing two regexes was worse performance so keeping the combined regex.

Before:

```
 ✓ src/index.bench.ts > typer.format 5205ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic type        15,977,178.63  0.0000  0.0468  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.08%  7988590
   · type with suffix  13,237,552.41  0.0000  0.0331  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.05%  6618777

 ✓ src/index.bench.ts > typer.parse 5273ms
     name                                    hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic type                   10,342,529.59  0.0000  0.2653  0.0001  0.0001  0.0001  0.0001  0.0003  ±0.62%  5171265
   · type with suffix              8,934,931.50  0.0000  0.2490  0.0001  0.0001  0.0001  0.0002  0.0005  ±0.35%  4467466
   · upper-case type with suffix   8,639,883.98  0.0000  0.2628  0.0001  0.0001  0.0001  0.0002  0.0005  ±0.43%  4319942

 ✓ src/index.bench.ts > typer.test 7375ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic type        16,299,085.64  0.0000  0.2822  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.13%  8149543
   · type with suffix  14,299,089.91  0.0000  0.0716  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.09%  7149546
   · invalid type      11,035,720.85  0.0000  0.0488  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.05%  5517861
```

After: 

```
 ✓ src/index.bench.ts > typer.format 5157ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic type        16,036,027.33  0.0000  0.1687  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.13%  8018014
   · type with suffix  12,971,083.09  0.0000  0.0478  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.08%  6485542

 ✓ src/index.bench.ts > typer.parse 5788ms
     name                                    hz     min      max    mean     p75     p99    p995    p999     rme  samples
   · basic type                   11,047,909.29  0.0000   0.4069  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.57%  5523955
   · type with suffix              9,894,087.39  0.0000  14.7271  0.0001  0.0001  0.0001  0.0001  0.0002  ±5.84%  4947044
   · upper-case type with suffix  10,207,665.14  0.0000   0.2047  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.36%  5103833

 ✓ src/index.bench.ts > typer.test 8161ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic type        18,896,733.21  0.0000  0.0299  0.0001  0.0001  0.0001  0.0001  0.0001  ±0.05%  9448367
   · type with suffix  16,784,829.36  0.0000  0.0665  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.07%  8392415
   · invalid type      13,560,077.97  0.0000  2.6157  0.0001  0.0001  0.0002  0.0002  0.0002  ±1.31%  6780039
```