### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
   ],
   "ts-scripts": {
     "project": "tsconfig.build.json"
+  },
+  "homepage": "https://github.com/jshttp/media-typer",
+  "bugs": {
+    "url": "https://github.com/jshttp/media-typer/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.