### PR TITLE
Should allow empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,10 +83,6 @@ function format (obj) {
  */
 
 function test (string) {
-  if (!string) {
-    throw new TypeError('argument string is required')
-  }
-
   if (typeof string !== 'string') {
     throw new TypeError('argument string is required to be a string')
   }
@@ -103,10 +99,6 @@ function test (string) {
  */
 
 function parse (string) {
-  if (!string) {
-    throw new TypeError('argument string is required')
-  }
-
   if (typeof string !== 'string') {
     throw new TypeError('argument string is required to be a string')
   }

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var assert = require('assert')
 var typer = require('..')
 
 var invalidTypes = [
+  '',
   ' ',
   'null',
   'undefined',
@@ -104,6 +105,10 @@ describe('typer.test(string)', function () {
 
   it('should pass upper-case type', function () {
     assert.strictEqual(typer.test('IMAGE/SVG+XML'), true)
+  })
+
+  it('should test empty string', function () {
+    assert.strictEqual(typer.test(''), false)
   })
 
   invalidTypes.forEach(function (type) {


### PR DESCRIPTION
Removes the empty check that rejects empty strings, seems like a footgun and has no test coverage so it may have been unintentional. Resolves the upstream issue in https://github.com/jshttp/type-is/pull/100.